### PR TITLE
Make this loop not overuse CPU core

### DIFF
--- a/source/fancontrol.c
+++ b/source/fancontrol.c
@@ -182,6 +182,7 @@ void FanControllerThreadFunction(void*)
             WriteLog("fanControllerSetRotationSpeedLevel error");
             diagAbortWithResult(MAKERESULT(Module_Libnx, LibnxError_ShouldNotHappen));
         }
+        svcSleepThread(100'000'000);
     }
 
     tsSessionClose(&ts_session);


### PR DESCRIPTION
This is a reason why your sysmodule is slowing down system. Never make a possibly infinite loop without adding some kind of sleep logic.